### PR TITLE
Propose new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,198 @@
-consul-replicate
-===========
+Consul Replicate
+================
+[![Latest Version](http://img.shields.io/github/release/hashicorp/consul-replicate.svg?style=flat-square)][release]
+[![Build Status](http://img.shields.io/travis/hashicorp/consul-replicate.svg?style=flat-square)][travis]
 
-consul-replicate integrates with [Consul](http://www.consul.io) to perform
-cross datacenter K/V replication.
+[release]: https://github.com/hashicorp/consul-replicate/releases
+[travis]: http://travis-ci.org/hashicorp/consul-replicate
 
-This makes it possible to manage application configuration from
-a central datacenter, with low-latency asyncronous replication
-to other datacenters. This avoids the need for smart clients
-which would need to write to all datacenters and queue writes
-to handle network failures.
+This project provides a convenient way to replicate K/V pairs across multiple [Consul][] datacenters using the `consul-replicate` daemon.
 
-consul-replicate uses a highly-available, pull based architecture.
-Multiple instances of consul-replicate can run per datacenter
-for redundancy and high-availablilty. They use Consul's
-[leader election](http://www.consul.io/docs/guides/leader-election.html)
-to elect a single node to perform the replication and gracefully
-failover. The active replicator watches the remote datacenter for
-changes and updates the local K/V store as appropriate.
+The daemon `consul-replicate` integrates with [Consul][] to perform cross-datacenter K/V replication. This makes it possible to manage application configuration from a central datacenter, with low-latency asyncronous replication to other datacenters, thus avoiding the need for smart clients which would need to write to all datacenters and queue writes to handle network failures.
 
-However, the daemon should not be used to attempt master-master
-replication. It is not designed for this use case, and will not
-ever reach a stable point. Instead, it should be used only
-for master-slave replication, where a single datacenter is considered
-authoritative.
+[Consul Replicate][] uses a highly-available, pull based architecture. Multiple instances of consul-replicate can run per datacenter for redundancy and high-availablilty. They use Consul's [leader election][] to elect a single node to perform the replication and gracefully failover. The active replicator watches the remote datacenter for changes and updates the local K/V store as appropriate. The daemon should not be used to attempt master-master replication. It is not designed for this use case, and will not ever reach a stable point. Instead, it should be used only for master-slave replication, where a single datacenter is considered authoritative.
 
-## Download & Usage
+**The documentation in this README corresponds to the master branch of Consul Replicate. It may contain unreleased features or different APIs than the most recently released version. Please see the Git tag that corresponds to your version of Consul Replicate for the proper documentation.**
 
-Download a release from the
-[releases page](#).
-Run `consul-replicate` to see the usage help:
 
-```
-$ consul-replicate -h
-Usage: consul-replicate [options]
+Installation
+------------
+You can download a released `consul-replicate` artifact from [the Consul Replicate release page][Releases] on GitHub. If you wish to compile from source, you will need to have buildtools and [Go][] installed:
 
-  Replicates K/V data from a source datacenter to the datacenter of
-  a Consul agent.
-
-Options:
-
-  -addr=127.0.0.1:8500  Provides the HTTP address of a Consul agent.
-  -dst-prefix=global/   Provides the prefix which is the root of replicated keys
-                        in the destination datacenter. Defaults to match source.
-  -lock=path            Lock is used to provide the path in the KV store used to
-                        perform leader election for the replicators. This ensures
-                        a single replicator running per-DC in a high-availability
-                        setup. Defaults to "service/consul-replicate/leader"
-  -prefix=global/       Provides the prefix which is the root of replicated keys
-                        in the source datacenter
-  -service=name         Service sets the name of the service that is registered
-                        in the catalog. Defaults to "consul-replicate"
-  -src=dc               Provides the source destination to replicate from
-  -status=path          Status is used to provide the path in the KV store used to
-                        store our replication status. This is to checkpoint replication
-                        periodically. Defaults to "service/consul-replicate/status"
-  -token=""             Optional ACL token to use when reading and writing keys.
+```shell
+$ git clone https://github.com/hashicorp/consul-replicate.git
+$ cd consul-replicate
+$ make
 ```
 
-## Example
+This process will create `bin/consul-replicate` which make be invoked as a binary.
 
-We run a [Consul demo cluster](http://demo.consul.io) that uses
-consul-replicate to perform cross datacenter replication. Specifically,
-keys in the `global/` prefix of the NYC3 datacenter are replicated to
-the [SFO1](http://sfo1.demo.consul.io/ui/#/sfo1/kv/) and
-[AMS2](http://ams2.demo.consul.io/ui/#/ams2/kv/) datacenters.
 
-We can test this by doing a write to NYC3:
+Usage
+-----
+### Options
+|       Option      | Description |
+| ----------------- |------------ |
+| `auth`            | The basic authentication username (and optional password), separated by a colon. There is no default value.
+| `consul`*         | The location of the Consul instance to query (may be an IP address or FQDN) with port.
+| `max-stale`       | The maximum staleness of a query. If specified, Consul will distribute work among all servers instead of just the leader. The default value is 0 (none).
+| `ssl`             | Use HTTPS while talking to Consul. Requires the Consul server to be configured to serve secure connections. The default value is false.
+| `ssl-verify`      | Verify certificates when connecting via SSL. This requires the use of `-ssl`. The default value is true.
+| `syslog`          | Send log output to syslog (in addition to stdout and stderr). The default value is false.
+| `syslog-facility` | The facility to use when sending to syslog. This requires the use of `-syslog`. The default value is `LOCAL0`.
+| `token`           | The [Consul API token][Consul ACLs]. There is no default value.
+| `prefix`*         | The source prefix including the datacenter, with optional destination prefix, separated by a colon (`:`). This option is additive and may be specified multiple times for multiple prefixes to replicate.
+| `wait`            | The `minimum(:maximum)` to wait for stability before replicating, separated by a colon (`:`). If the optional maximum value is omitted, it is assumed to be 4x the required minimum value. There is no default value.
+| `retry`           | The amount of time to wait if Consul returns an error when communicating with the API. The default value is 5 seconds.
+| `config`          | The path to a configuration file or directory of configuration files on disk, relative to the current working directory. Values specified on the CLI take precedence over values specified in the configuration file. There is no default value.
+| `log-level`       | The log level for output. This applies to the stdout/stderr logging as well as syslog logging (if enabled). Valid values are "debug", "info", "warn", and "err". The default value is "warn".
+| `once`            | Run Consul Replicate once and exit (as opposed to the default behavior of daemon). _(CLI-only)_
+| `version`         | Output version information and quit. _(CLI-only)_
 
+\* = Required parameter
+
+Additionally. the following options are available for advanced users. It is not recommended you change these values unless you have a specific use case.
+
+|       Option      | Description |
+| ----------------- |------------ |
+| `lock`            | The path in the KV store that is used to perform leader election for the replicators. The default value is "service/consul-replicate/leader".
+| `status`          | The path in the KV store that is used to store the replication status. The default value is "service/consul-replicate/status".
+| `service`         | The name of the service that is registered in Consul's catalog. The default value is "consul-replicate".
+
+
+### Command Line
+The CLI interface supports all of the options detailed above.
+
+Replicate all keys under "global" from the nyc1 datacenter:
+
+```shell
+$ consul-replicate \
+  -prefix "global@nyc1"
 ```
-$ curl -X PUT -d test http://nyc3.demo.consul.io/v1/kv/global/foo
-true
+
+Replicate all keys under "global" from the nyc1 datacenter, renaming the key to "default" in the replicated stores:
+
+```shell
+$ consul-replicate \
+  -prefix "global@nyc1:default"
 ```
 
-We should now be able to read the key from all the datacenters:
+Replicate all keys under "global" from the nyc1 datacenter, but do not poll or watch for changes (just do it one time):
 
-```
-$ curl http://nyc3.demo.consul.io/v1/kv/global/foo
-[{"CreateIndex":21123,"ModifyIndex":21123,"LockIndex":0,"Key":"global/foo","Flags":0,"Value":"dGVzdA=="}]
-
-$ curl http://sfo1.demo.consul.io/v1/kv/global/foo
-[{"CreateIndex":21123,"ModifyIndex":21123,"LockIndex":0,"Key":"global/foo","Flags":0,"Value":"dGVzdA=="}]
-
-$ curl http://ams2.demo.consul.io/v1/kv/global/foo
-[{"CreateIndex":21123,"ModifyIndex":21123,"LockIndex":0,"Key":"global/foo","Flags":0,"Value":"dGVzdA=="}]
+```shell
+$ consul-replicate \
+  -prefix "global@nyc1" \
+  -once
 ```
 
+### Configuration File(s)
+The Consul Replicate configuration files are written in [HashiCorp Configuration Language (HCL)][HCL]. By proxy, this means the Consul Replicate configuration file is JSON-compatible. For more information, please see the [HCL specification][HCL].
+
+The Configuration file syntax interface supports all of the options detailed above, unless otherwise noted in the table.
+
+```javascript
+consul = "127.0.0.1:8500"
+token = "abcd1234"
+retry = "10s"
+max_stale = "10m"
+
+auth {
+  enabled = true
+  username = "test"
+  password = "test"
+}
+
+ssl {
+  enabled = true
+  verify = false
+}
+
+syslog {
+  enabled = true
+  facility = "LOCAL5"
+}
+
+prefix {
+  source = "global@nyc1"
+}
+
+
+prefix {
+  source = "global@nyc1"
+  destination = "default"
+}
+
+prefix {
+  // Multiple prefix definitions are supported
+}
+```
+
+If a directory is given instead of a file, all files in the directory (recursively) will be merged in [lexical order](http://golang.org/pkg/path/filepath/#Walk). So if multiple files declare a "consul" key for instance, the last one will be used.
+
+**Commands specified on the command line take precedence over those defined in a config file!**
+
+
+Debugging
+---------
+Consul Replicate can print verbose debugging output. To set the log level for Consul Replicate, use the `-log-level` flag:
+
+```shell
+$ consul-replicate -log-level info ...
+```
+
+```text
+<timestamp> [INFO] (cli) received redis from Watcher
+<timestamp> [INFO] (cli) invoking Runner
+# ...
+```
+
+You can also specify the level as debug:
+
+```shell
+$ consul-replicate -log-level debug ...
+```
+
+```text
+TODO
+# ...
+```
+
+
+FAQ
+---
+**Q: Cam I use this for master-master replication?**<br>
+A: No, a proper leader will never be elected.
+
+
+Contributing
+------------
+To hack on Consul Replicate, you will need a modern [Go][] environment. To compile the `consul-replicate` binary and run the test suite, simply execute:
+
+```shell
+$ make
+```
+
+This will compile the `consul-replicate` binary into `bin/consul-replicate` and run the test suite.
+
+If you just want to run the tests:
+
+```shell
+$ make
+```
+
+Or to run a specific test in the suite:
+
+```shell
+go test ./... -run SomeTestFunction_name
+```
+
+Submit Pull Requests and Issues to the [Consul Replicate project on GitHub][Consul Replicate].
+
+
+[Consul]: http://consul.io/ "Service discovery and configuration made easy"
+[leader election]: http://www.consul.io/docs/guides/leader-election.html "Consul Leader election"
+[Releases]: https://github.com/hashicorp/consul-replicate/releases "Consul Replicate releases page"
+[HCL]: https://github.com/hashicorp/hcl "HashiCorp Configuration Language (HCL)"
+[Go]: http://golang.org "Go the language"
+[Consul ACLs]: http://www.consul.io/docs/internals/acl.html "Consul ACLs"
+[Consul Replicate]: https://github.com/hashicorp/consul-replicate "Consul Replicate on GitHub"

--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/hashicorp/consul-template/logging"
+	"github.com/hashicorp/consul-template/watch"
+)
+
+// Exit codes are int values that represent an exit code for a particular error.
+// Sub-systems may check this unique error to determine the cause of an error
+// without parsing the output or help text.
+//
+// Errors start at 10
+const (
+	ExitCodeOK int = 0
+
+	ExitCodeError = 10 + iota
+	ExitCodeInterrupt
+)
+
+/// ------------------------- ///
+
+// CLI is the main entry point for Consul Replicate.
+type CLI struct {
+	sync.Mutex
+
+	// outSteam and errStream are the standard out and standard error streams to
+	// write messages from the CLI.
+	outStream, errStream io.Writer
+
+	// stopCh is an internal channel used to trigger a shutdown of the CLI.
+	stopCh  chan struct{}
+	stopped bool
+}
+
+func NewCLI(out, err io.Writer) *CLI {
+	return &CLI{
+		outStream: out,
+		errStream: err,
+		stopCh:    make(chan struct{}),
+	}
+}
+
+// Run accepts a slice of arguments and returns an int representing the exit
+// status from the command.
+func (cli *CLI) Run(args []string) int {
+	// Parse the flags
+	config, once, dry, version, err := cli.parseFlags(args[1:])
+	if err != nil {
+		return cli.handleError(err, ExitCodeParseFlagsError)
+	}
+
+	// Setup the logging
+	if err := logging.Setup(&logging.Config{
+		Name:           Name,
+		Level:          config.LogLevel,
+		Syslog:         config.Syslog.Enabled,
+		SyslogFacility: config.Syslog.Facility,
+		Writer:         cli.errStream,
+	}); err != nil {
+		return cli.handleError(err, ExitCodeLoggingError)
+	}
+
+	// If the version was requested, return an "error" containing the version
+	// information. This might sound weird, but most *nix applications actually
+	// print their version on stderr anyway.
+	if version {
+		log.Printf("[DEBUG] (cli) version flag was given, exiting now")
+		fmt.Fprintf(cli.errStream, "%s v%s\n", Name, Version)
+		return ExitCodeOK
+	}
+
+	// Initial runner
+	runner, err := NewRunner(config, dry, once)
+	if err != nil {
+		return cli.handleError(err, ExitCodeRunnerError)
+	}
+	go runner.Start()
+
+	// Listen for signals
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT,
+	)
+
+	for {
+		select {
+		case err := <-runner.ErrCh:
+			return cli.handleError(err, ExitCodeRunnerError)
+		case <-runner.DoneCh:
+			return ExitCodeOK
+		case s := <-signalCh:
+			switch s {
+			case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT:
+				fmt.Fprintf(cli.errStream, "Received interrupt, cleaning up...\n")
+				runner.Stop()
+				return ExitCodeInterrupt
+			case syscall.SIGHUP:
+				fmt.Fprintf(cli.errStream, "Received HUP, reloading configuration...\n")
+				runner.Stop()
+				runner, err = NewRunner(config, dry, once)
+				if err != nil {
+					return cli.handleError(err, ExitCodeRunnerError)
+				}
+				go runner.Start()
+			}
+		case <-cli.stopCh:
+			return ExitCodeOK
+		}
+	}
+}
+
+// stop is used internally to shutdown a running CLI
+func (cli *CLI) stop() {
+	cli.Lock()
+	defer cli.Unlock()
+
+	if cli.stopped {
+		return
+	}
+
+	close(cli.stopCh)
+	cli.stopped = true
+}
+
+// parseFlags is a helper function for parsing command line flags using Go's
+// Flag library. This is extracted into a helper to keep the main function
+// small, but it also makes writing tests for parsing command line arguments
+// much easier and cleaner.
+func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, error) {
+	var dry, once, version bool
+	var config = DefaultConfig()
+
+	// Parse the flags and options
+	flags := flag.NewFlagSet(Name, flag.ContinueOnError)
+	flags.SetOutput(cli.errStream)
+	flags.Usage = func() {
+		fmt.Fprintf(cli.errStream, usage, Name)
+	}
+	flags.StringVar(&config.Consul, "consul", config.Consul, "")
+	flags.StringVar(&config.Token, "token", config.Token, "")
+	flags.Var((*authVar)(config.Auth), "auth", "")
+	flags.BoolVar(&config.SSL.Enabled, "ssl", config.SSL.Enabled, "")
+	flags.BoolVar(&config.SSL.Verify, "ssl-verify", config.SSL.Verify, "")
+	flags.DurationVar(&config.MaxStale, "max-stale", config.MaxStale, "")
+	flags.BoolVar(&config.Syslog.Enabled, "syslog", config.Syslog.Enabled, "")
+	flags.StringVar(&config.Syslog.Facility, "syslog-facility", config.Syslog.Facility, "")
+	flags.Var((*watch.WaitVar)(config.Wait), "wait", "")
+	flags.DurationVar(&config.Retry, "retry", config.Retry, "")
+	flags.StringVar(&config.Path, "config", config.Path, "")
+	flags.StringVar(&config.LogLevel, "log-level", config.LogLevel, "")
+	flags.BoolVar(&dry, "dry", false, "")
+	flags.BoolVar(&version, "version", false, "")
+
+	// Deprecated options
+	var deprecatedAddr bool
+	flags.StringVar(&deprecatedAddr, "addr", config.Consul, "")
+
+	// If there was a parser error, stop
+	if err := flags.Parse(args); err != nil {
+		return nil, false, false, false, err
+	}
+
+	// Handle deprecations
+	if deprecatedAddr != "" {
+		log.Printf("[WARN] -addr is deprecated - please use -consul=<...> instead")
+		config.Consul = deprecatedAddr
+	}
+
+	return config, once, dry, version, nil
+}
+
+// handleError outputs the given error's Error() to the errStream and returns
+// the given exit status.
+func (cli *CLI) handleError(err error, status int) int {
+	fmt.Fprintf(cli.errStream, "Consul Replicate returned errors:\n%s", err)
+	return status
+}
+
+const usage = `
+Usage: %s [options]
+
+  Replicates key-value data from a source datacenter to the datacenter(s) of a
+  Consul agent.
+
+Options:
+
+  -auth=<user[:pass]>      Set the basic authentication username (and password)
+  -consul=<address>        Sets the address of the Consul instance
+  -max-stale=<duration>    Set the maximum staleness and allow stale queries to
+                           Consul which will distribute work among all servers
+                           instead of just the leader
+  -ssl                     Use SSL when connecting to Consul
+  -ssl-verify              Verify certificates when connecting via SSL
+  -token=<token>           Sets the Consul API token
+
+  -syslog                  Send the output to syslog instead of standard error
+                           and standard out. The syslog facility defaults to
+                           LOCAL0 and can be changed using a configuration file
+  -syslog-facility=<f>     Set the facility where syslog should log. If this
+                           attribute is supplied, the -syslog flag must also be
+                           supplied.
+
+  -prefix=<src[:dest]>     Provides the source prefix in the replicating
+                           datacenter and optionally the destination prefix in
+                           the destination datacenters - if the destination is
+                           omitted, it is assumed to be the same as the source
+  -wait=<duration>         Sets the 'minumum(:maximum)' amount of time to wait
+                           for stability before replicating
+  -retry=<duration>        The amount of time to wait if Consul returns an
+                           error when communicating with the API
+
+  -config=<path>           Sets the path to a configuration file on disk
+
+  -log-level=<level>       Set the logging level - valid values are "debug",
+                           "info", "warn" (default), and "err"
+
+  -once                    Do not run the process as a daemon
+  -version                 Print the version of this daemon
+
+Advanced Options:
+
+  -lock=<path>             Sets the path in the KV store that is used to perform
+                           leader election for the replicators (default:
+                           "service/consul-replicate/leader")
+  -status=<path>           Sets the path in the KV store that is used to store
+                           the replication status (default:
+                           "service/consul-replicate/status")
+  -service=<name>          Sets the name of the service that is registered in
+                           Consul's catalog (default: "consul-replicate")
+`
+
+// TODO: Handle deprecations/updates for the following options:
+//
+// -dst-prefix=global/   Provides the prefix which is the root of replicated keys
+//                       in the destination datacenter. Defaults to match source.
+// -prefix=global/       Provides the prefix which is the root of replicated keys
+//                       in the source datacenter
+// -src=dc               Provides the source destination to replicate from


### PR DESCRIPTION
/cc @mitchellh @armon @ryanuber for feedback.

This basically proposes a new API (with little code change right now) just to get some early feedback. The primary motivation for this change is two-fold:

1. Bring Consul Replicate up to snuff with Consul Template and envconsul
2. Support multiple prefixes

The biggest change is the "syntax" for specifying a prefix. The user can now specify both the source and destination like `source@dc:destination`. This allows the user to specify multiple KV pairs and their destinations independently. 