### PR TITLE
fix config merge ordering

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -75,8 +75,12 @@ type Runner struct {
 func NewRunner(config *Config, once bool) (*Runner, error) {
 	log.Printf("[INFO] (runner) creating new runner (once: %v)", once)
 
+	// configuration settings override the defaults
+	mergedDefaultConfig := DefaultConfig()
+	mergedDefaultConfig.Merge(config)
+
 	runner := &Runner{
-		config: config,
+		config: mergedDefaultConfig,
 		once:   once,
 	}
 
@@ -204,9 +208,6 @@ func (r *Runner) init() error {
 			return fmt.Errorf("runner: %s", err)
 		}
 	}
-
-	// Add default values for the config
-	r.config.Merge(DefaultConfig())
 
 	// Create the client
 	client, err := newAPIClient(r.config)

--- a/runner_test.go
+++ b/runner_test.go
@@ -29,8 +29,9 @@ func TestNewRunner_initialize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if runner.config != config {
-		t.Errorf("expected %#v to be %#v", runner.config, config)
+	// check the items we set in the config
+	if !reflect.DeepEqual(runner.config.Prefixes, config.Prefixes) {
+		t.Errorf("expected %#v to be %#v", runner.config.Prefixes, config.Prefixes)
 	}
 
 	if runner.once != once {
@@ -96,6 +97,19 @@ func TestReceive_addsToData(t *testing.T) {
 	}
 	if !reflect.DeepEqual(value.Data, data) {
 		t.Errorf("expected %q to be %q", value.Data, data)
+	}
+}
+
+func TestConfigDefaultOverrides(t *testing.T) {
+	expected := "test/statuses"
+
+	config := &Config{
+		StatusDir: expected,
+	}
+
+	r, _ := NewRunner(config, true)
+	if r.config.StatusDir != expected {
+		t.Errorf("expected StatusDir %q to be %q", r.config.StatusDir, expected)
 	}
 }
 


### PR DESCRIPTION
The default config struct was being merged in such a way that the default configuration was overwriting values set on the command line or in a config file. This change modifies this such that all set configuration parameters override the defaults, rather than the other way around. 