### PR TITLE
Fix problems when destination folders do not exist

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -316,8 +316,11 @@ func TestParseFlags_prefixes(t *testing.T) {
 	if prefix.SourceRaw != "global@nyc1" {
 		t.Errorf("expected %q to be %q", prefix.SourceRaw, "global@nyc1")
 	}
-	if prefix.Destination != "backup" {
-		t.Errorf("expected %q to be %q", prefix.Destination, "backup")
+	// destination prefix must end in a slash so it will be created as a folder
+	// if it does not already exist
+	expectedDestination := "backup/"
+	if prefix.Destination != expectedDestination {
+		t.Errorf("expected %q to be %q", prefix.Destination, expectedDestination)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -336,6 +336,8 @@ func ParsePrefix(s string) (*Prefix, error) {
 	if destination == "" {
 		destination = source.Prefix
 	}
+	// ensure destination prefix ends with "/"
+	destination = strings.TrimSuffix(destination, "/") + "/"
 
 	return &Prefix{
 		Source:      source,

--- a/config_test.go
+++ b/config_test.go
@@ -362,6 +362,13 @@ func TestParsePrefix_source(t *testing.T) {
 	if prefix.Source.Prefix != source {
 		t.Errorf("expected %q to be %q", prefix.Source.Prefix, source)
 	}
+
+	// if destination is not explicitly specified, source will be copied to destination
+	// destination may not exist, so the destination folder must end with a slash
+	expectedDestination := "global/"
+	if prefix.Destination != expectedDestination {
+		t.Errorf("expected %q to be %q", prefix.Destination, expectedDestination)
+	}
 }
 
 func TestParsePrefix_sourceSlash(t *testing.T) {
@@ -390,8 +397,10 @@ func TestParsePrefix_destination(t *testing.T) {
 	if prefix.SourceRaw != "global@nyc4" {
 		t.Errorf("expected %q to be %q", prefix.SourceRaw, "global@nyc4")
 	}
-	if prefix.Destination != destination {
-		t.Errorf("expected %q to be %q", prefix.Destination, destination)
+	// destination must have a slash appended to it
+	expectedDestination := "backup/"
+	if prefix.Destination != expectedDestination {
+		t.Errorf("expected %q to be %q", prefix.Destination, expectedDestination)
 	}
 	if prefix.Source.Prefix != "global" {
 		t.Errorf("expected %q to be %q", prefix.Source.Prefix, "global")

--- a/runner.go
+++ b/runner.go
@@ -287,7 +287,7 @@ func (r *Runner) replicate(prefix *Prefix, doneCh chan struct{}, errCh chan erro
 	updates := 0
 	usedKeys := make(map[string]struct{}, len(pairs))
 	for _, pair := range pairs {
-		key := filepath.Join(prefix.Destination, pair.Key)
+		key := prefix.Destination + pair.Key
 		usedKeys[key] = struct{}{}
 
 		// Ignore if the modify index is old


### PR DESCRIPTION
When building the full KV path for the destination path, the Runner.replicate() function uses the filepath.Join() function to build the path. However, this function makes assumptions around file paths that do not hold true for Consul KV paths. Specifically, the function drops the final slash from the path if it exists, but in Consul the final slash represents a different path, and represents a folder, not a key.

This also seemingly caused problems on Windows, where the filepath.Join() function used backslashes instead of slashes to join the path elements (as seen in #27).

Finally, these issues also caused permissions problems because of the stripped trailing slash. An ACL with write access to "config/global/" was refused the ability to sync that path because the existing code attempted to create a key (not a folder) at "config/global" without the trailing slash, and the result was a 403 error. However, while permissions to write to "config/global" would fix this, it would also allow writing to other paths, such as "config/global-fail/oops", which may not be desired.

This patchset fixes these problems by just concatenating the KV path with a slash, and by forcing the destination path (which may not exist) to end in a slash.

Tests are also included for the config side (the runner.go code is not structured to allow testing of this code path).