### PR TITLE
Ensure config file is loaded

### DIFF
--- a/config.go
+++ b/config.go
@@ -70,6 +70,10 @@ type Config struct {
 // Merge merges the values in config into this config object. Values in the
 // config object overwrite the values in c.
 func (c *Config) Merge(config *Config) {
+	if config.Path != "" {
+		c.Path = config.Path
+	}
+
 	if config.Consul != "" {
 		c.Consul = config.Consul
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -127,6 +127,19 @@ func TestMerge_SyslogOptions(t *testing.T) {
 	}
 }
 
+func TestMerge_Path(t *testing.T) {
+	config := &Config{}
+	path := "file/path.hcl"
+	otherConfig := &Config{
+		Path: path,
+	}
+	config.Merge(otherConfig)
+
+	if config.Path != path {
+		t.Errorf("expected config.Path (%q) to be %q", config.Path, path)
+	}
+}
+
 // Test that file read errors are propagated up
 func TestParseConfig_readFileError(t *testing.T) {
 	_, err := ParseConfig(path.Join(os.TempDir(), "config.json"))


### PR DESCRIPTION
As reported in #32, any config file specified on the command line was being ignored.

The Config.Merge() function did not attempt to merge the `Path` field, and so any command-line specified config file path was being lost when `DefaultConfig()` was being merged with the provided config.

This PR should fix this issue.