### PR TITLE
Fix problems when destination folders do not exist

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -283,8 +283,8 @@ func TestParseFlags_prefixes(t *testing.T) {
 	}
 
 	prefix := config.Prefixes[0]
-	if prefix.Destination != "backup" {
-		t.Errorf("expected %q to be %q", prefix.Destination, "backup")
+	if prefix.Destination != "backup/" {
+		t.Errorf("expected %q to be %q", prefix.Destination, "backup/")
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -505,6 +505,8 @@ func ParsePrefix(s string) (*Prefix, error) {
 	if destination == "" {
 		destination = source.Prefix
 	}
+	// ensure destination prefix ends with "/"
+	destination = strings.TrimSuffix(destination, "/") + "/"
 
 	return &Prefix{
 		Source:      source,

--- a/config_test.go
+++ b/config_test.go
@@ -346,6 +346,13 @@ func TestParsePrefix_source(t *testing.T) {
 	if prefix.Source.Prefix != source {
 		t.Errorf("expected %q to be %q", prefix.Source.Prefix, source)
 	}
+
+	// if destination is not explicitly specified, source will be copied to destination
+	// destination may not exist, so the destination folder must end with a slash
+	expectedDestination := "global/"
+	if prefix.Destination != expectedDestination {
+		t.Errorf("expected %q to be %q", prefix.Destination, expectedDestination)
+	}
 }
 
 func TestParsePrefix_sourceSlash(t *testing.T) {
@@ -368,8 +375,8 @@ func TestParsePrefix_destination(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if prefix.Destination != destination {
-		t.Errorf("expected %q to be %q", prefix.Destination, destination)
+	if prefix.Destination != "backup/" {
+		t.Errorf("expected %q to be %q", prefix.Destination, "backup/")
 	}
 	if prefix.Source.Prefix != "global" {
 		t.Errorf("expected %q to be %q", prefix.Source.Prefix, "global")

--- a/runner.go
+++ b/runner.go
@@ -297,7 +297,7 @@ func (r *Runner) replicate(prefix *Prefix, doneCh chan struct{}, errCh chan erro
 	updates := 0
 	usedKeys := make(map[string]struct{}, len(pairs))
 	for _, pair := range pairs {
-		key := filepath.Join(prefix.Destination, pair.Key)
+		key := prefix.Destination + pair.Key
 		usedKeys[key] = struct{}{}
 
 		// Ignore if the modify index is old


### PR DESCRIPTION
* Force destination prefix to end in a slash and be treated as a folder.
* Do not use file path join function to build consul KV paths, since
  the behavior on Windows is to use a backslash rather than a slash.
* Add test cases to ensure the destination always ends in a slash.