### PR TITLE
Added the ability to exclude specific prefixes from replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Usage
 | `syslog-facility` | The facility to use when sending to syslog. This requires the use of `-syslog`. The default value is `LOCAL0`.
 | `token`           | The [Consul API token][Consul ACLs]. There is no default value.
 | `prefix`*         | The source prefix including the , with optional destination prefix, separated by a colon (`:`). This option is additive and may be specified multiple times for multiple prefixes to replicate.
+| `exclude`*        | A prefix to exclude replication of. This option is additive and may be specified multiple times for multiple prefixes to replicate.
 | `wait`            | The `minimum(:maximum)` to wait for stability before replicating, separated by a colon (`:`). If the optional maximum value is omitted, it is assumed to be 4x the required minimum value. There is no default value.
 | `retry`           | The amount of time to wait if Consul returns an error when communicating with the API. The default value is 5 seconds.
 | `config`          | The path to a configuration file or directory of configuration files on disk, relative to the current working directory. Values specified on the CLI take precedence over values specified in the configuration file. There is no default value.
@@ -119,6 +120,10 @@ prefix {
 
 prefix {
   // Multiple prefix definitions are supported
+}
+
+exclude {
+  source = "vault/core/lock"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Usage
 | `syslog-facility` | The facility to use when sending to syslog. This requires the use of `-syslog`. The default value is `LOCAL0`.
 | `token`           | The [Consul API token][Consul ACLs]. There is no default value.
 | `prefix`*         | The source prefix including the , with optional destination prefix, separated by a colon (`:`). This option is additive and may be specified multiple times for multiple prefixes to replicate.
-| `exclude`*        | A prefix to exclude replication of. This option is additive and may be specified multiple times for multiple prefixes to replicate.
+| `exclude`         | A prefix to exclude during replication. This option is additive and may be specified multiple times for multiple prefixes to exclude.
 | `wait`            | The `minimum(:maximum)` to wait for stability before replicating, separated by a colon (`:`). If the optional maximum value is omitted, it is assumed to be 4x the required minimum value. There is no default value.
 | `retry`           | The amount of time to wait if Consul returns an error when communicating with the API. The default value is 5 seconds.
 | `config`          | The path to a configuration file or directory of configuration files on disk, relative to the current working directory. Values specified on the CLI take precedence over values specified in the configuration file. There is no default value.
@@ -78,6 +78,15 @@ Replicate all keys under "global" from the nyc1 , but do not poll or watch for c
 ```shell
 $ consul-replicate \
   -prefix "global@nyc1" \
+  -once
+```
+
+Replicate all keys under "global" from the nyc1 , but exclude the global/private prefix:
+
+```shell
+$ consul-replicate \
+  -prefix "global@nyc1" \
+  -exclude "global/private" \
   -once
 ```
 

--- a/cli.go
+++ b/cli.go
@@ -241,6 +241,14 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, error) {
 		return nil
 	}), "prefix", "")
 
+	flags.Var((funcVar)(func(s string) error {
+		if config.Excludes == nil {
+			config.Excludes = make([]*Exclude, 0, 1)
+		}
+		config.Excludes = append(config.Excludes, &Exclude{Source: s})
+		return nil
+	}), "exclude", "")
+
 	flags.Var((funcBoolVar)(func(b bool) error {
 		config.Syslog.Enabled = b
 		config.set("syslog")
@@ -381,6 +389,9 @@ Options:
   -prefix=<src[:dest]>     Provides the source prefix in the replicating
                            datacenter and optionally the destination prefix in
                            the destination datacenters - if the destination is
+                           omitted, it is assumed to be the same as the source
+  -exclude=<src>           Provides a prefix to exclude from replication
+  
                            omitted, it is assumed to be the same as the source
   -wait=<duration>         Sets the 'minumum(:maximum)' amount of time to wait
                            before replicating

--- a/cli.go
+++ b/cli.go
@@ -392,7 +392,6 @@ Options:
                            omitted, it is assumed to be the same as the source
   -exclude=<src>           Provides a prefix to exclude from replication
   
-                           omitted, it is assumed to be the same as the source
   -wait=<duration>         Sets the 'minumum(:maximum)' amount of time to wait
                            before replicating
   -retry=<duration>        The amount of time to wait if Consul returns an

--- a/cli_test.go
+++ b/cli_test.go
@@ -288,6 +288,25 @@ func TestParseFlags_prefixes(t *testing.T) {
 	}
 }
 
+func TestParseFlags_excludes(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, err := cli.parseFlags([]string{
+		"-exclude", "excluded/",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(config.Excludes) != 1 {
+		t.Fatal("expected 1 exclude")
+	}
+
+	exclude := config.Excludes[0]
+	if exclude.Source != "excluded/" {
+		t.Errorf("expected %q to be %q", exclude.Source, "excluded/")
+	}
+}
+
 func TestParseFlags_syslog(t *testing.T) {
 	cli := NewCLI(ioutil.Discard, ioutil.Discard)
 	config, _, _, err := cli.parseFlags([]string{

--- a/config.go
+++ b/config.go
@@ -121,7 +121,7 @@ func (c *Config) Copy() *Config {
 	config.Excludes = make([]*Exclude, len(c.Excludes))
 	for i, p := range c.Excludes {
 		config.Excludes[i] = &Exclude{
-			Source:      p.Source,
+			Source: p.Source,
 		}
 	}
 
@@ -241,7 +241,7 @@ func (c *Config) Merge(config *Config) {
 
 		for _, exclude := range config.Excludes {
 			c.Excludes = append(c.Excludes, &Exclude{
-				Source:      exclude.Source,
+				Source: exclude.Source,
 			})
 		}
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -184,6 +184,32 @@ func TestMerge_Prefixes(t *testing.T) {
 	}
 }
 
+func TestMerge_Excludes(t *testing.T) {
+	config1 := testConfig(`
+		exclude {
+			source = "foo"
+		}
+	`, t)
+	config2 := testConfig(`
+		exclude {
+			source = "foo-2"
+		}
+	`, t)
+	config1.Merge(config2)
+
+	if len(config1.Excludes) != 2 {
+		t.Fatalf("bad excludes %d", len(config1.Excludes))
+	}
+
+	if config1.Excludes[0].Source != "foo" {
+		t.Errorf("bad source: %#v", config1.Excludes[0].Source)
+	}
+
+	if config1.Excludes[1].Source != "foo-2" {
+		t.Errorf("bad source: %#v", config1.Excludes[1].Source)
+	}
+}
+
 func TestMerge_wait(t *testing.T) {
 	config1 := testConfig(`
 		wait = "1s:1s"

--- a/config_test.go
+++ b/config_test.go
@@ -257,6 +257,7 @@ func TestParseConfig_correctValues(t *testing.T) {
 			Password: "test",
 		},
 		Prefixes: []*Prefix{},
+		Excludes: []*Exclude{},
 		SSL: &SSLConfig{
 			Enabled: true,
 			Verify:  false,

--- a/runner.go
+++ b/runner.go
@@ -306,9 +306,9 @@ func (r *Runner) replicate(prefix *Prefix, excludes []*Exclude, doneCh chan stru
 		if len(excludes) > 0 {
 			excluded := false
 			for _, exclude := range excludes {
-				if strings.HasPrefix(key, exclude.Source) {
-					log.Printf("[DEBUG] (runner) key %q has prefix %q, excluding"+
-						key, exclude.Source)
+				if strings.HasPrefix(pair.Path, exclude.Source) {
+					log.Printf("[DEBUG] (runner) key %q has prefix %q, excluding",
+						pair.Path, exclude.Source)
 					excluded = true
 				}
 			}

--- a/runner_test.go
+++ b/runner_test.go
@@ -15,6 +15,9 @@ func TestNewRunner_initialize(t *testing.T) {
 			&Prefix{SourceRaw: "3", Destination: "6"},
 			&Prefix{SourceRaw: "4", Destination: "7"},
 		},
+		Excludes: []*Exclude{
+			&Exclude{Source: "3"},
+		},
 	}
 
 	runner, err := NewRunner(config, once)

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -64,6 +64,7 @@ echo $CONSUL_REPLICATE_BIN
 $CONSUL_REPLICATE_BIN \
   -consul $ADDRESS_DC2 \
   -prefix "global@dc1:backup" \
+  -exclude "global/555" \
   -log-level $LOG_LEVEL &
 CONSUL_REPLICATE_PID=$!
 sleep 5
@@ -80,7 +81,11 @@ echo
 echo "CHECKING DC2 FOR REPLICATION"
 for i in `seq 1 1000`;
 do
-    curl -s $ADDRESS_DC2/v1/kv/backup/$i | grep "dGVzdCBkYXRh"
+    if [ $i -ne "555" ]; then
+        curl -s $ADDRESS_DC2/v1/kv/backup/$i | grep "dGVzdCBkYXRh"
+    else
+        curl -sw '%{http_code}' $ADDRESS_DC2/v1/kv/backup/$i | grep "404"
+    fi
 done
 
 echo


### PR DESCRIPTION
Using consul-replicate with Vault and other things, I found the ability to exclude certain keys/prefixes from being replicated was useful, so I added an exclude field to the config to enable this sort of thing:
```hcl
exclude {
  source = "vault/core/lock"
}
```
Any thoughts/feedback on this?