### PR TITLE
Feature/client tls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ _testmain.go
 
 /bin
 /pkg
+
+# Vim
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Usage
 | `max-stale`       | The maximum staleness of a query. If specified, Consul will distribute work among all servers instead of just the leader. The default value is 0 (none).
 | `ssl`             | Use HTTPS while talking to Consul. Requires the Consul server to be configured to serve secure connections. The default value is false.
 | `ssl-verify`      | Verify certificates when connecting via SSL. This requires the use of `-ssl`. The default value is true.
+| `ssl-cert`        | SSL certificate to use for authenticating with Consul. This requires the use of `-ssl`
+| `ssl-key`         | SSL certificate key to use for authenticating with Consul. This requires the use of `-ssl`
+| `ssl-ca-cert`     | CACert to use to verify the Consul certificate. This requires the use of `-ssl`
 | `syslog`          | Send log output to syslog (in addition to stdout and stderr). The default value is false.
 | `syslog-facility` | The facility to use when sending to syslog. This requires the use of `-syslog`. The default value is `LOCAL0`.
 | `token`           | The [Consul API token][Consul ACLs]. There is no default value.
@@ -111,6 +114,8 @@ auth {
 ssl {
   enabled = true
   verify = false
+  cert = "/path/to/my/cert"
+  key = "/path/to/my/key"
 }
 
 syslog {

--- a/runner.go
+++ b/runner.go
@@ -3,10 +3,12 @@ package main
 import (
 	"crypto/md5"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -534,15 +536,47 @@ func newAPIClient(config *Config) (*api.Client, error) {
 	if config.SSL.Enabled {
 		log.Printf("[DEBUG] (runner) enabling SSL")
 		consulConfig.Scheme = "https"
-	}
 
-	if !config.SSL.Verify {
-		log.Printf("[WARN] (runner) disabling SSL verification")
-		consulConfig.HttpClient.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
+		var tlsConfig tls.Config
+
+		// Custom certificate or certificate and key
+		if config.SSL.Cert != "" && config.SSL.Key != "" {
+			log.Printf("[DEBUG] (runner) loading ssl cert %s and ssl key %s", config.SSL.Cert, config.SSL.Key)
+			cert, err := tls.LoadX509KeyPair(config.SSL.Cert, config.SSL.Key)
+			if err != nil {
+				return nil, fmt.Errorf("runner: Could not load certificate: %s", err)
+			}
+			tlsConfig.Certificates = []tls.Certificate{cert}
+		} else if config.SSL.Cert != "" {
+			log.Printf("[DEBUG] (runner) loading ssl cert and key from %s", config.SSL.Cert)
+			cert, err := tls.LoadX509KeyPair(config.SSL.Cert, config.SSL.Cert)
+			if err != nil {
+				return nil, fmt.Errorf("runner: Could not load certificate: %s", err)
+			}
+			tlsConfig.Certificates = []tls.Certificate{cert}
 		}
+
+		// Custom CA certificate
+		if config.SSL.CaCert != "" {
+			cacert, err := ioutil.ReadFile(config.SSL.CaCert)
+			if err != nil {
+				return nil, fmt.Errorf("runner: Could not read cacert: %s", err)
+			}
+			caCertPool := x509.NewCertPool()
+			caCertPool.AppendCertsFromPEM(cacert)
+
+			tlsConfig.RootCAs = caCertPool
+		}
+
+		// Construct all the certificates now
+		tlsConfig.BuildNameToCertificate()
+
+		if !config.SSL.Verify {
+			log.Printf("[WARN] (runner) disabling SSL verification")
+			tlsConfig.InsecureSkipVerify = true
+		}
+
+		consulConfig.HttpClient.Transport = &http.Transport{TLSClientConfig: &tlsConfig}
 	}
 
 	if config.Auth != nil {
@@ -572,8 +606,11 @@ func newWatcher(config *Config, client *api.Client, once bool) (*watch.Watcher, 
 		AuthEnabled:  config.Auth.Enabled,
 		AuthUsername: config.Auth.Username,
 		AuthPassword: config.Auth.Password,
+		SSLCert:      config.SSL.Cert,
+		SSLKey:	      config.SSL.Key,
 		SSLEnabled:   config.SSL.Enabled,
 		SSLVerify:    config.SSL.Verify,
+		SSLCACert:    config.SSL.CaCert,
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR implements authentication via client tls certificates and adds an option to specify a custom cacert.

The CLI-Opts were already present (since 8f6610b934420934835637df905ec808dac63547) but had no effect.