### PR TITLE
Better exclude

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -263,6 +263,14 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, error) {
 		return nil
 	}), "exclude", "")
 
+  flags.Var((funcVar)(func(s string) error {
+		if c.ExcludeMatches == nil {
+			c.ExcludeMatches = make([]*ExcludeMatch, 0, 1)
+		}
+		c.ExcludeMatches = append(c.ExcludeMatches, &ExcludeMatch{Source: s})
+		return nil
+	}), "excludematch", "")
+
 	flags.Var((funcBoolVar)(func(b bool) error {
 		c.Syslog.Enabled = b
 		c.set("syslog")
@@ -409,6 +417,8 @@ Options:
                            the destination datacenters - if the destination is
                            omitted, it is assumed to be the same as the source
   -exclude=<src>           Provides a prefix to exclude from replication
+
+  -excludematch=<src>      Provides a path match to exclude from replication
 
   -wait=<duration>         Sets the 'minumum(:maximum)' amount of time to wait
                            before replicating

--- a/cli_test.go
+++ b/cli_test.go
@@ -306,6 +306,25 @@ func TestParseFlags_excludes(t *testing.T) {
 	}
 }
 
+func TestParseFlags_excludematches(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, err := cli.parseFlags([]string{
+		"-excludematch", "excludematched/",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(config.ExcludeMatches) != 1 {
+		t.Fatal("expected 1 exclude match")
+	}
+
+	excludematch := config.ExcludeMatches[0]
+	if excludematch.Source != "excludematched/" {
+		t.Errorf("expected %q to be %q", excludematch.Source, "excludematched/")
+	}
+}
+
 func TestParseFlags_syslog(t *testing.T) {
 	cli := NewCLI(ioutil.Discard, ioutil.Discard)
 	config, _, _, err := cli.parseFlags([]string{

--- a/config.go
+++ b/config.go
@@ -37,6 +37,9 @@ type Config struct {
 	// Excludes is the list of key prefixes to exclude from replication.
 	Excludes []*Exclude `mapstructure:"exclude"`
 
+  // ExcludeMatches is the list of key match expressions to exclude from replication.
+	ExcludeMatches []*ExcludeMatch `mapstructure:"excludematch"`
+
 	// Auth is the HTTP basic authentication for communicating with Consul.
 	Auth *AuthConfig `mapstructure:"auth"`
 
@@ -125,6 +128,13 @@ func (c *Config) Copy() *Config {
 	o.Excludes = make([]*Exclude, len(c.Excludes))
 	for i, p := range c.Excludes {
 		o.Excludes[i] = &Exclude{
+			Source: p.Source,
+		}
+	}
+
+	o.ExcludeMatches = make([]*ExcludeMatch, len(c.ExcludeMatches))
+	for i, p := range c.ExcludeMatches {
+		o.ExcludeMatches[i] = &ExcludeMatch{
 			Source: p.Source,
 		}
 	}
@@ -255,6 +265,18 @@ func (c *Config) Merge(o *Config) {
 		for _, exclude := range o.Excludes {
 			c.Excludes = append(c.Excludes, &Exclude{
 				Source: exclude.Source,
+			})
+		}
+	}
+
+	if o.ExcludeMatches != nil {
+		if c.ExcludeMatches == nil {
+			c.ExcludeMatches = []*ExcludeMatch{}
+		}
+
+		for _, excludematch := range o.ExcludeMatches {
+			c.ExcludeMatches = append(c.ExcludeMatches, &ExcludeMatch{
+				Source: excludematch.Source,
 			})
 		}
 	}
@@ -426,6 +448,7 @@ func DefaultConfig() *Config {
 		LogLevel:  logLevel,
 		Prefixes:  []*Prefix{},
 		Excludes:  []*Exclude{},
+		ExcludeMatches:  []*ExcludeMatch{},
 		Retry:     5 * time.Second,
 		StatusDir: "service/consul-replicate/statuses",
 		Wait: &config.WaitConfig{
@@ -529,6 +552,11 @@ type Prefix struct {
 
 // Exclude is a key path prefix to exclude from replication
 type Exclude struct {
+	Source string `mapstructure:"source"`
+}
+
+// Exclude is a key path match to exclude from replication
+type ExcludeMatch struct {
 	Source string `mapstructure:"source"`
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -257,6 +257,32 @@ func TestMerge_Excludes(t *testing.T) {
 	}
 }
 
+func TestMerge_ExcludeMatches(t *testing.T) {
+	config1 := testConfig(`
+		excludematch {
+			source = "foo"
+		}
+	`, t)
+	config2 := testConfig(`
+		excludematch {
+			source = "foo-2"
+		}
+	`, t)
+	config1.Merge(config2)
+
+	if len(config1.ExcludeMatches) != 2 {
+		t.Fatalf("bad exclude matches %d", len(config1.ExcludeMatches))
+	}
+
+	if config1.ExcludeMatches[0].Source != "foo" {
+		t.Errorf("bad source: %#v", config1.ExcludeMatches[0].Source)
+	}
+
+	if config1.ExcludeMatches[1].Source != "foo-2" {
+		t.Errorf("bad source: %#v", config1.ExcludeMatches[1].Source)
+	}
+}
+
 func TestMerge_wait(t *testing.T) {
 	config1 := testConfig(`
 		wait = "1s:1s"
@@ -331,6 +357,7 @@ func TestParseConfig_correctValues(t *testing.T) {
 		},
 		Prefixes: []*Prefix{},
 		Excludes: []*Exclude{},
+		ExcludeMatches: []*ExcludeMatch{},
 		SSL: &SSLConfig{
 			Enabled: true,
 			Verify:  false,

--- a/runner_test.go
+++ b/runner_test.go
@@ -18,6 +18,9 @@ func TestNewRunner_initialize(t *testing.T) {
 		Excludes: []*Exclude{
 			&Exclude{Source: "3"},
 		},
+		ExcludeMatches: []*ExcludeMatch{
+			&ExcludeMatch{Source: "2"},
+		},
 	}
 
 	runner, err := NewRunner(config, once)

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -90,6 +90,7 @@ $CONSUL_REPLICATE_BIN \
   -consul $ADDRESS_DC2 \
   -prefix "global@dc1:backup" \
   -exclude "global/$EXCLUDED_KEY" \
+  -excludematch "excluded_" \
   -log-level $LOG_LEVEL &
 CONSUL_REPLICATE_PID=$!
 sleep 3

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -99,6 +99,7 @@ curl -sLo /dev/null -X PUT $ADDRESS_DC1/v1/kv/global/six -d "six"
 sleep 3
 curl -sL $ADDRESS_DC2/v1/kv/backup/six | grep -q "c2l4"
 
+echo "##Test Case #1"
 echo "    Writing a key in DC2"
 curl -sLo /dev/null -X PUT $ADDRESS_DC2/v1/kv/backup/$EXCLUDED_KEY/nodelete -d "don't delete"
 sleep 3
@@ -109,6 +110,18 @@ sleep 3
 
 echo "    Checking key still exists in DC2"
 curl -sL $ADDRESS_DC2/v1/kv/backup/$EXCLUDED_KEY/nodelete | grep -q "ZG9uJ3QgZGVsZXRl"
+
+echo "##Test Case #2"
+echo "    Writing a key in DC2"
+curl -sLo /dev/null -X PUT $ADDRESS_DC2/v1/kv/backup/excluded_key -d "don't delete"
+sleep 3
+
+echo "    Updating prefix in DC1"
+curl -sLo /dev/null -X PUT $ADDRESS_DC1/v1/kv/global/parent_folder/other_folder/anykey -d "test data"
+sleep 3
+
+echo "    Checking key still exists in DC2"
+curl -sL $ADDRESS_DC2/v1/kv/backup/excluded_key | grep -q "ZG9uJ3QgZGVsZXRl"
 
 rm -rf $DATADIR_DC1
 rm -rf $DATADIR_DC2


### PR DESCRIPTION
I added a "better" way to exclude changes (and more importantly deletes!) from being propagated. There's a simple test to show how a key gets clobbered unless it is excluded. I don't think it's obvious from the documentation that each change (+ quiescence period) the **ENTIRE** kv tree is traversed. I'll file that away as a future enhancement once I'm a little more go-competent.