### PR TITLE
Add a monitoring script for Consul-Replicate

### DIFF
--- a/monitoring/datadog/README
+++ b/monitoring/datadog/README
@@ -1,0 +1,14 @@
+DataDog Agent Check for Consul-Replicate
+===
+
+This check helps in monitoring the health of consul-replicate.
+
+To configure the check, write the master DC path into Consul KV
+and set it as `master_dc_path` in the check configuration (the
+.yaml file).
+
+For each replicated KV store prefix or value that you wish to monitor,
+add an entry under `check_paths` with the full KV path to a value that
+changes frequently. The check will read that value from both local
+and master DC Consul clusters and output a metric that tells whether
+the value is readable and whether it is the same between the clusters.

--- a/monitoring/datadog/consul_replicate_check.py
+++ b/monitoring/datadog/consul_replicate_check.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+import json
+import urllib2
+import subprocess
+from checks import AgentCheck
+
+
+class ConsulReplicateCheck(AgentCheck):
+    metrics_prefix = 'consul-replicate.'
+
+    def check(self, instance):
+        my_dc = self.read_my_dc()
+        tags = ["dc:" + my_dc]
+
+        error = self.replicate_running(tags)
+        try:
+            master_dc = self.read_kv(instance['master_dc_path'])
+        except urllib2.HTTPError as e:
+            print("Failed to read the value for replication master DC at path %s: %s"
+                  % (instance['master_dc_path'], e))
+            return False
+
+        self.gauge(self.metrics_prefix + "in_master_dc",
+                   1 if master_dc == my_dc else 0, tags)
+
+        if master_dc == my_dc:
+            # No point checking paths
+            return error
+
+        for path in instance['check_paths']:
+            error = error and self.check_path(path, master_dc, tags)
+        return error
+
+    def read_my_dc(self):
+        agent_self = urllib2.urlopen("http://127.0.0.1:8500/v1/agent/self")
+        j = json.load(agent_self)
+        agent_self.close()
+        return j['Config']['Datacenter']
+
+    def replicate_running(self, tags):
+        retcode = subprocess.call(
+            ["/bin/ps", "-C", "consul-replicate", "--no-headers"])
+        if retcode != 0 and retcode != 1:
+            return False
+        self.gauge(self.metrics_prefix + "running", 1 - retcode, tags)
+        return True
+
+    def check_path(self, path, master_dc, tags):
+        tags_with_prefix = list(tags)
+        tags_with_prefix.append("prefix:" + path.split('/')[0])
+        readable = 1
+
+        try:
+            equal = self.read_kv(path) == self.read_kv(path, master_dc)
+            self.gauge(self.metrics_prefix + "value_mismatch",
+                       0 if equal else 1, tags_with_prefix)
+        except urllib2.HTTPError as e:
+            print("Failed to check values at path %s: %s" % (path, e))
+            readable = 0
+
+        self.gauge(self.metrics_prefix + "value_readable",
+                   readable, tags_with_prefix)
+
+        return True
+
+    def read_kv(self, path, dc=None):
+        url = "http://127.0.0.1:8500/v1/kv/" + path + "?raw"
+        if dc:
+            url = url + "&dc=" + dc
+
+        kv = urllib2.urlopen(url)
+        raw = kv.read()
+        kv.close()
+        return raw
+
+
+if __name__ == '__main__':
+    check, instances = ConsulReplicateCheck.from_yaml(
+        '/etc/dd-agent/conf.d/consul_replicate_check.yaml')
+    for instance in instances:
+        print "\nRunning the check"
+        check.check(instance)
+        if check.has_events():
+            print 'Events: %s' % (check.get_events())
+        print 'Metrics: %s' % (check.get_metrics())
+

--- a/monitoring/datadog/consul_replicate_check.yaml
+++ b/monitoring/datadog/consul_replicate_check.yaml
@@ -1,0 +1,7 @@
+---
+init_config:
+instances:
+- master_dc_path: path/to/master_dc_value/in_kv_store
+  check_paths:
+  - replicate_prefix/sample_frequently_changing_value
+  - another_prefix/another_value


### PR DESCRIPTION
There doesn't seem to be much available around monitoring
of Consul-Replicate, and sometimes it does get stuck. While
this is not a solution for everyone, it helps anyone using
Datadog and also provides a template that can be used for
other monitoring systems.