### PR TITLE
Add optional delete flag for destination key deletion

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -381,6 +381,11 @@ func (cli *CLI) ParseFlags(args []string) (*Config, []string, bool, bool, error)
 		return nil
 	}), "wait", "")
 
+	flags.Var((funcBoolVar)(func(b bool) error {
+		c.DeleteKey = config.Bool(b)
+		return nil
+	}), "delete", "")
+
 	flags.BoolVar(&isVersion, "v", false, "")
 	flags.BoolVar(&isVersion, "version", false, "")
 
@@ -617,6 +622,10 @@ Options:
   -wait=<duration>
       Sets the 'min(:max)' amount of time to wait before writing a template (and
       triggering a command)
+
+  -delete=<boolean>
+      Enables deletion of keys in the destination datacenter that do not exist
+      in the source datacenter. Defaults to true
 
   -v, -version
       Print the version of this daemon


### PR DESCRIPTION
This PR is made to provide a more effective approach to handling consul-replicate key deletions. In the previous [PR](https://github.com/hashicorp/consul-replicate/pull/110), the operator would be prompted to confirm if deletion should be initiated for destination keys that corresponded to removed source keys. This would be an issue if consul-replicate was daemonized, where there isn't a way to input an answer to the prompt. 

This solution will allow operators to set a delete flag when starting consul-replicate from an interactive shell or for a daemon. 

Example: 
Deleting keys in source DC
<img width="640" alt="Cursor_and_ec2-user_ip-172-31-39-175__" src="https://user-images.githubusercontent.com/29156090/226057712-27174818-8110-435b-add1-d7b7e744eb5d.png">

Running `consul-replicate -config "replicate.hcl" -delete=false` in destination DC.

<img width="914" alt="ec2-user_ip-172-31-40-166__" src="https://user-images.githubusercontent.com/29156090/226058092-52d32a5d-4017-41a5-b4d2-0cb0b4370fd8.png">